### PR TITLE
TravisCI fixes

### DIFF
--- a/{{cookiecutter.service_name}}/.travis.yml
+++ b/{{cookiecutter.service_name}}/.travis.yml
@@ -8,10 +8,8 @@ addons:
     - apt-transport-https
 
 install:
-  - git fetch --unshallow --tags
   - pip install PyYAML
   - pip install virtualenv
-  - pip install reno
   - |
     test -e Gemfile || cat <<EOF > Gemfile
     source 'https://rubygems.org'

--- a/{{cookiecutter.service_name}}/tests/pip_requirements.txt
+++ b/{{cookiecutter.service_name}}/tests/pip_requirements.txt
@@ -1,0 +1,1 @@
++jsonschema

--- a/{{cookiecutter.service_name}}/tests/run_tests.sh
+++ b/{{cookiecutter.service_name}}/tests/run_tests.sh
@@ -195,7 +195,7 @@ run() {
 real_run() {
     for pillar in ${PILLARDIR}/*.sls; do
         state_name=$(basename ${pillar%.sls})
-        salt_run --id=${state_name} state.sls ${FORMULA_NAME} || { log_err "Execution of ${FORMULA_NAME}.${state_name} failed"; exit 1; }
+        salt_run -m ${DEPSDIR}/salt-formula-salt --id=${state_name} state.sls ${FORMULA_NAME} || { log_err "Execution of ${FORMULA_NAME}.${state_name} failed"; exit 1; }
     done
 }
 


### PR DESCRIPTION
* Removing reno which installation dies with:  DEPRECATION: Uninstalling a distutils installed project (six) has been deprecated and will be removed in a future version.

* Removing "git fetch --unshallow --tags" which dies on: The command "git fetch --unshallow --tags" failed and exited with 128 during .
